### PR TITLE
injecting service in a method of controller

### DIFF
--- a/DIMethodInjection/DIMethodInjectionPresentation/Controllers/HomeController.cs
+++ b/DIMethodInjection/DIMethodInjectionPresentation/Controllers/HomeController.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+﻿using DIMethodInjectionSampleService.Interfaces;
 using System.Web.Mvc;
 
 namespace DIMethodInjectionPresentation.Controllers
@@ -10,6 +7,8 @@ namespace DIMethodInjectionPresentation.Controllers
     {
         public ActionResult Index()
         {
+            ISampleService _sampleService = (ISampleService)DependencyResolver.Current.GetService(typeof(ISampleService));
+            var myName = _sampleService.GetName();
             return View();
         }
 

--- a/DIMethodInjection/DIMethodInjectionPresentation/Global.asax.cs
+++ b/DIMethodInjection/DIMethodInjectionPresentation/Global.asax.cs
@@ -1,6 +1,6 @@
 ﻿using DIMethodInjectionPresentation.App_Start;
-using DIMethodInjectionSampleService.Interfaces;
 using DIMethodInjectionSampleService.Implementations;
+using DIMethodInjectionSampleService.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using System.Web.Mvc;
 using System.Web.Optimization;
@@ -20,7 +20,7 @@ namespace DIMethodInjectionPresentation
 
             var services = new ServiceCollection();
 
-            services.AddTransient<ISampleServices, SampleService>();
+            services.AddTransient<ISampleService, SampleService>();
 
             ServiceProvider = services.BuildServiceProvider();
 

--- a/DIMethodInjection/DIMethodInjectionSampleService/DIMethodInjectionSampleService.csproj
+++ b/DIMethodInjection/DIMethodInjectionSampleService/DIMethodInjectionSampleService.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Implementations\SampleService.cs" />
-    <Compile Include="Interfaces\ISampleServices.cs" />
+    <Compile Include="Interfaces\ISampleService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/DIMethodInjection/DIMethodInjectionSampleService/Implementations/SampleService.cs
+++ b/DIMethodInjection/DIMethodInjectionSampleService/Implementations/SampleService.cs
@@ -2,7 +2,7 @@
 
 namespace DIMethodInjectionSampleService.Implementations
 {
-    public class SampleService : ISampleServices
+    public class SampleService : ISampleService
     {
         public string GetName()
         {

--- a/DIMethodInjection/DIMethodInjectionSampleService/Interfaces/ISampleService.cs
+++ b/DIMethodInjection/DIMethodInjectionSampleService/Interfaces/ISampleService.cs
@@ -1,6 +1,6 @@
 ﻿namespace DIMethodInjectionSampleService.Interfaces
 {
-    public interface ISampleServices
+    public interface ISampleService
     {
         string GetName();
     }


### PR DESCRIPTION
Injecting service in a method of controller (workaround for .NET Framework 4.7.2) 
- there is no native way to do it using Microsoft.Extensions.DependencyInjection 
- fix name of Interface